### PR TITLE
Add article: Releasing cooklang codeblock plugin for Obsidian

### DIFF
--- a/src/content/articles/2026-07-01-releasing-cooklang-codeblock-plugin-for-obsidian.mdx
+++ b/src/content/articles/2026-07-01-releasing-cooklang-codeblock-plugin-for-obsidian.mdx
@@ -6,4 +6,4 @@ category: post
 
 I'm releasing a new plugin for Obsidian that lets you embed a recipe written in cooklang within an Obsidian note. Recipes on this website such as [Palak Paneer](/blog/palak-paneer) or [Chai](/blog/chai) have all been written using cooklang and then formatted using the cooklang alongwith a custom Astro component. Embedding custom components within markdown is why I've always preferred `mdx` as the default document format.
 
-However, Obsidian provides a customizable codeblock formatter that lets me visualize a formatted recipe from a cooklang codeblock within a markdown file itself and how this plugin came to be: [Cooklang Codeblock](https://community.obsidian.md/plugins/cooklang-codeblock)
+However, Obsidian provides a customizable codeblock formatter that lets me visualize a formatted recipe from a cooklang codeblock within a markdown file itself. Install here: [Cooklang Codeblock](https://community.obsidian.md/plugins/cooklang-codeblock).

--- a/src/content/articles/2026-07-01-releasing-cooklang-codeblock-plugin-for-obsidian.mdx
+++ b/src/content/articles/2026-07-01-releasing-cooklang-codeblock-plugin-for-obsidian.mdx
@@ -1,0 +1,9 @@
+---
+title: Releasing cooklang codeblock plugin for Obsidian
+date: 2026-07-01
+category: post
+---
+
+I'm releasing a new plugin for Obsidian that lets you embed a recipe written in cooklang within an Obsidian note. Recipes on this website such as [Palak Paneer](/blog/palak-paneer) or [Chai](/blog/chai) have all been written using cooklang and then formatted using the cooklang alongwith a custom Astro component. Embedding custom components within markdown is why I've always preferred `mdx` as the default document format.
+
+However, Obsidian provides a customizable codeblock formatter that lets me visualize a formatted recipe from a cooklang codeblock within a markdown file itself and how this plugin came to be: [Cooklang Codeblock](https://community.obsidian.md/plugins/cooklang-codeblock)


### PR DESCRIPTION
## Summary
- New post announcing the Cooklang Codeblock plugin for Obsidian

🤖 Generated with [Claude Code](https://claude.com/claude-code)